### PR TITLE
Make `hx` properly handle being passed invalid paths

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,9 +234,9 @@ pub fn run(matches: ArgMatches) -> Result<(), Box<dyn Error>> {
         let mut buf: Box<dyn BufRead> = if is_stdin.unwrap() {
             Box::new(BufReader::new(io::stdin()))
         } else {
-            Box::new(BufReader::new(
-                fs::File::open(matches.value_of(ARG_INP).unwrap()).unwrap(),
-            ))
+            Box::new(BufReader::new(fs::File::open(
+                matches.value_of(ARG_INP).unwrap(),
+            )?))
         };
         let mut format_out = Format::LowerHex;
         let mut colorize = true;
@@ -285,7 +285,7 @@ pub fn run(matches: ArgMatches) -> Result<(), Box<dyn Error>> {
             let mut ascii_line: Line = Line::new();
             let mut offset_counter: u64 = 0x0;
             let mut byte_column: u64 = 0x0;
-            let page = buf_to_array(&mut buf, truncate_len, column_width).unwrap();
+            let page = buf_to_array(&mut buf, truncate_len, column_width)?;
 
             for line in page.body.iter() {
                 print_offset(offset_counter);
@@ -433,7 +433,7 @@ pub fn buf_to_array(
     let mut page: Page = Page::new();
     let mut line: Line = Line::new();
     for b in buf.bytes() {
-        let b1: u8 = b.unwrap();
+        let b1: u8 = b?;
         line.bytes += 1;
         page.bytes += 1;
         line.hex_body.push(b1);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ use std::error::Error;
 use std::f64;
 use std::fs;
 use std::io::BufReader;
-use std::io::{self, BufRead, Read};
+use std::io::{self, BufRead, Read, Write};
 
 /// arg cols
 pub const ARG_COL: &str = "cols";
@@ -134,8 +134,8 @@ pub fn offset(b: u64) -> String {
 }
 
 /// print offset to std out
-pub fn print_offset(b: u64) {
-    print!("{}: ", offset(b));
+pub fn print_offset(w: &mut impl Write, b: u64) -> io::Result<()> {
+    write!(w, "{}: ", offset(b))
 }
 
 /// hex octal, takes u8
@@ -159,7 +159,7 @@ pub fn hex_binary(b: u8) -> String {
 }
 
 /// print byte to std out
-pub fn print_byte(b: u8, format: Format, colorize: bool) {
+pub fn print_byte(w: &mut impl Write, b: u8, format: Format, colorize: bool) -> io::Result<()> {
     let mut color: u8 = b;
     if color < 1 {
         color = 0x16;
@@ -167,39 +167,43 @@ pub fn print_byte(b: u8, format: Format, colorize: bool) {
     if colorize {
         // note, for color testing: for (( i = 0; i < 256; i++ )); do echo "$(tput setaf $i)This is ($i) $(tput sgr0)"; done
         match format {
-            Format::Octal => print!(
+            Format::Octal => write!(
+                w,
                 "{} ",
                 ansi_term::Style::new()
                     .fg(ansi_term::Color::Fixed(color))
                     .paint(hex_octal(b))
             ),
-            Format::LowerHex => print!(
+            Format::LowerHex => write!(
+                w,
                 "{} ",
                 ansi_term::Style::new()
                     .fg(ansi_term::Color::Fixed(color))
                     .paint(hex_lower_hex(b))
             ),
-            Format::UpperHex => print!(
+            Format::UpperHex => write!(
+                w,
                 "{} ",
                 ansi_term::Style::new()
                     .fg(ansi_term::Color::Fixed(color))
                     .paint(hex_upper_hex(b))
             ),
-            Format::Binary => print!(
+            Format::Binary => write!(
+                w,
                 "{} ",
                 ansi_term::Style::new()
                     .fg(ansi_term::Color::Fixed(color))
                     .paint(hex_binary(b))
             ),
-            _ => print!("unk_fmt "),
+            _ => write!(w, "unk_fmt "),
         }
     } else {
         match format {
-            Format::Octal => print!("{} ", hex_octal(b)),
-            Format::LowerHex => print!("{} ", hex_lower_hex(b)),
-            Format::UpperHex => print!("{} ", hex_upper_hex(b)),
-            Format::Binary => print!("{} ", hex_binary(b)),
-            _ => print!("unk_fmt "),
+            Format::Octal => write!(w, "{} ", hex_octal(b)),
+            Format::LowerHex => write!(w, "{} ", hex_lower_hex(b)),
+            Format::UpperHex => write!(w, "{} ", hex_upper_hex(b)),
+            Format::Binary => write!(w, "{} ", hex_binary(b)),
+            _ => write!(w, "unk_fmt "),
         }
     }
 }
@@ -274,7 +278,7 @@ pub fn run(matches: ArgMatches) -> Result<(), Box<dyn Error>> {
 
         // array output mode is mutually exclusive
         if let Some(array) = matches.value_of(ARG_ARR) {
-            output_array(array, buf, truncate_len, column_width);
+            output_array(array, buf, truncate_len, column_width)?;
         } else {
             // Transforms this Read instance to an Iterator over its bytes.
             // The returned type implements Iterator where the Item is
@@ -287,13 +291,16 @@ pub fn run(matches: ArgMatches) -> Result<(), Box<dyn Error>> {
             let mut byte_column: u64 = 0x0;
             let page = buf_to_array(&mut buf, truncate_len, column_width)?;
 
+            let stdout = io::stdout();
+            let mut locked = stdout.lock();
+
             for line in page.body.iter() {
-                print_offset(offset_counter);
+                print_offset(&mut locked, offset_counter)?;
 
                 for hex in line.hex_body.iter() {
                     offset_counter += 1;
                     byte_column += 1;
-                    print_byte(*hex, format_out, colorize);
+                    print_byte(&mut locked, *hex, format_out, colorize)?;
 
                     if *hex > 31 && *hex < 127 {
                         ascii_line.ascii.push(*hex as char);
@@ -303,17 +310,21 @@ pub fn run(matches: ArgMatches) -> Result<(), Box<dyn Error>> {
                 }
 
                 if byte_column < column_width {
-                    print!("{:<1$}", "", 5 * (column_width - byte_column) as usize);
+                    write!(
+                        locked,
+                        "{:<1$}",
+                        "",
+                        5 * (column_width - byte_column) as usize
+                    )?;
                 }
 
                 byte_column = 0x0;
                 let ascii_string: String = ascii_line.ascii.iter().cloned().collect();
                 ascii_line = Line::new();
-                print!("{}", ascii_string); // print ascii string
-                println!();
+                write!(locked, "{}\n", ascii_string)?; // print ascii string
             }
             if true {
-                println!("   bytes: {}", page.bytes);
+                writeln!(locked, "   bytes: {}", page.bytes)?;
             }
         }
     }
@@ -367,33 +378,41 @@ pub fn output_array(
     mut buf: Box<dyn BufRead>,
     truncate_len: u64,
     column_width: u64,
-) {
+) -> io::Result<()> {
+    let stdout = io::stdout();
+    let mut locked = stdout.lock();
+
     let page = buf_to_array(&mut buf, truncate_len, column_width).unwrap();
     match array_format {
-        "r" => println!("let ARRAY: [u8; {}] = [", page.bytes),
-        "c" => println!("unsigned char ARRAY[{}] = {{", page.bytes),
-        "g" => println!("a := [{}]byte{{", page.bytes),
-        _ => println!("unknown array format"),
+        "r" => writeln!(locked, "let ARRAY: [u8; {}] = [", page.bytes)?,
+        "c" => writeln!(locked, "unsigned char ARRAY[{}] = {{", page.bytes)?,
+        "g" => writeln!(locked, "a := [{}]byte{{", page.bytes)?,
+        _ => writeln!(locked, "unknown array format")?,
     }
     let mut i: u64 = 0x0;
     for line in page.body.iter() {
-        print!("    ");
+        write!(locked, "    ")?;
         for hex in line.hex_body.iter() {
             i += 1;
             if i == page.bytes && array_format != "g" {
-                print!("{}", hex_lower_hex(*hex));
+                write!(locked, "{}", hex_lower_hex(*hex))?;
             } else {
-                print!("{}, ", hex_lower_hex(*hex));
+                write!(locked, "{}, ", hex_lower_hex(*hex))?;
             }
         }
-        println!();
+        writeln!(locked, "")?;
     }
-    match array_format {
-        "r" => println!("];"),
-        "c" => println!("}};"),
-        "g" => println!("}}"),
-        _ => println!("unknown array format"),
-    }
+
+    writeln!(
+        locked,
+        "{}",
+        match array_format {
+            "r" => "];",
+            "c" => "};",
+            "g" => "}",
+            _ => "unknown array format",
+        }
+    )
 }
 
 /// Function wave out.


### PR DESCRIPTION
Fixes #26.
Fixes #23.

With this PR `hx` is now able to properly report an error when it is given a directory, an invalid filename or a broken pipe:

```shell
# All those cases crashed previously.

❯ ./target/release/hx filename-missing
error = "No such file or directory (os error 2)"

❯ ./target/release/hx src
error = "Is a directory (os error 21)"

❯ ./target/release/hx symlink_to_dir
error = "Is a directory (os error 21)"

❯ dd if=/dev/random bs=512 count=10 | RUST_BACKTRACE=1 ./target/debug/hx | head -n 10
10+0 records in
10+0 records out
5120 bytes transferred in 0.000036 secs (142217460 bytes/sec)
0x000000: 0x6c 0xdc 0x4f 0x43 0xfd 0x5e 0xb3 0xa7 0x79 0xaa l.OC.^..y.
0x00000a: 0x6b 0x2c 0x81 0x47 0x00 0x10 0xa6 0x40 0xb5 0x6a k,.G...@.j
0x000014: 0x4d 0x31 0x5b 0x11 0x15 0x71 0xb8 0xa1 0xff 0x91 M1[..q....
0x00001e: 0x2e 0xaa 0x69 0x77 0x52 0x2a 0x20 0xa6 0x52 0xe5 ..iwR* .R.
0x000028: 0x41 0x2b 0x83 0x55 0x21 0x41 0x33 0xae 0xf8 0x38 A+.U!A3..8
0x000032: 0xba 0x74 0xfe 0x23 0xc2 0xc9 0xf5 0x3d 0x28 0x8e .t.#...=(.
0x00003c: 0xbc 0x0e 0xe1 0xa3 0xbf 0xda 0x81 0x92 0xc6 0xe9 ..........
0x000046: 0x9f 0xb7 0x13 0x72 0x79 0xd3 0x1e 0x4c 0xd8 0x5d ...ry..L.]
0x000050: 0x85 0x36 0x91 0x9f 0x13 0x7e 0x55 0x5f 0x7b 0xa6 .6...~U_{.
0x00005a: 0x23 0xe7 0xed 0x54 0x47 0x9a 0x1c 0x54 0x91 0x85 #..TG..T..
error = "Broken pipe (os error 32)"
```