### PR TITLE
Add more byte array output formats (Python, Kotlin, Java)

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ FLAGS:
     -V, --version    Prints version information
 
 OPTIONS:
-    -a, --array <array_format>    Set source code format output: rust (r), C (c), golang (g) [possible values: r, c, g]
+    -a, --array <array_format>    Set source code format output: rust (r), C (c), golang (g), python (p) [possible values: r, c, g, p]
     -t, --color <color>           Set color tint terminal output. 0 to disable, 1 to enable [possible values: 0, 1]
     -c, --cols <columns>          Set column length
     -f, --format <format>         Set format of octet: Octal (o), LowerHex (x), UpperHex (X), Binary (b) [possible

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ If `<USERDIR>/.cargo/bin` is part of the `PATH` environment variable, `hx` shoul
 
 ### output arrays in `rust`, `c` or `golang`
 
-`hx` has a feature which can output the input file bytes as source code arrays. 
+`hx` has a feature which can output the input file bytes as source code arrays.
 
 For example:
 
@@ -124,6 +124,15 @@ $ hx -ag -c8 tests/files/tiny.txt
 a := [3]byte{
     0x69, 0x6c, 0x0a,
 }
+```
+
+#### python array: -ap
+
+```sh
+$ hx -ap -c8 tests/files/tiny.txt
+a = [
+    0x69, 0x6c, 0x0a
+]
 ```
 
 ## manual

--- a/README.md
+++ b/README.md
@@ -135,6 +135,24 @@ a = [
 ]
 ```
 
+#### kotlin array: -ak
+
+```sh
+$ hx -ak -c8 tests/files/tiny.txt
+val a = byteArrayOf(
+    0x69, 0x6c, 0x0a
+)
+```
+
+#### java array: -aj
+
+```sh
+$ hx -aj -c8 tests/files/tiny.txt
+byte[] a = new byte[]{
+    0x69, 0x6c, 0x0a
+};
+```
+
 ## manual
 
 ```txt
@@ -150,7 +168,7 @@ FLAGS:
     -V, --version    Prints version information
 
 OPTIONS:
-    -a, --array <array_format>    Set source code format output: rust (r), C (c), golang (g), python (p) [possible values: r, c, g, p]
+    -a, --array <array_format>    Set source code format output: rust (r), C (c), golang (g), python (p), kotlin (k), java (j) [possible values: r, c, g, p, k, j]
     -t, --color <color>           Set color tint terminal output. 0 to disable, 1 to enable [possible values: 0, 1]
     -c, --cols <columns>          Set column length
     -f, --format <format>         Set format of octet: Octal (o), LowerHex (x), UpperHex (X), Binary (b) [possible

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -381,6 +381,7 @@ pub fn output_array(
         "r" => writeln!(locked, "let ARRAY: [u8; {}] = [", page.bytes)?,
         "c" => writeln!(locked, "unsigned char ARRAY[{}] = {{", page.bytes)?,
         "g" => writeln!(locked, "a := [{}]byte{{", page.bytes)?,
+        "p" => writeln!(locked, "a = [")?,
         _ => writeln!(locked, "unknown array format")?,
     }
     let mut i: u64 = 0x0;
@@ -404,6 +405,7 @@ pub fn output_array(
             "r" => "];",
             "c" => "};",
             "g" => "}",
+            "p" => "]",
             _ => "unknown array format",
         }
     )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -382,6 +382,8 @@ pub fn output_array(
         "c" => writeln!(locked, "unsigned char ARRAY[{}] = {{", page.bytes)?,
         "g" => writeln!(locked, "a := [{}]byte{{", page.bytes)?,
         "p" => writeln!(locked, "a = [")?,
+        "k" => writeln!(locked, "val a = byteArrayOf(")?,
+        "j" => writeln!(locked, "byte[] a = new byte[]{{")?,
         _ => writeln!(locked, "unknown array format")?,
     }
     let mut i: u64 = 0x0;
@@ -403,9 +405,10 @@ pub fn output_array(
         "{}",
         match array_format {
             "r" => "];",
-            "c" => "};",
+            "c" | "j" => "};",
             "g" => "}",
             "p" => "]",
+            "k" => ")",
             _ => "unknown array format",
         }
     )

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,8 +58,8 @@ fn main() {
                 .short("a")
                 .long(ARG_ARR)
                 .value_name("array_format")
-                .help("Set source code format output: rust (r), C (c), golang (g), python (p)")
-                .possible_values(&["r", "c", "g", "p"])
+                .help("Set source code format output: rust (r), C (c), golang (g), python (p), kotlin (k), java (j)")
+                .possible_values(&["r", "c", "g", "p", "k", "j"])
                 .takes_value(true),
         )
         .arg(

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,8 +58,8 @@ fn main() {
                 .short("a")
                 .long(ARG_ARR)
                 .value_name("array_format")
-                .help("Set source code format output: rust (r), C (c), golang (g)")
-                .possible_values(&["r", "c", "g"])
+                .help("Set source code format output: rust (r), C (c), golang (g), python (p)")
+                .possible_values(&["r", "c", "g", "p"])
                 .takes_value(true),
         )
         .arg(


### PR DESCRIPTION
This is useful when dealing with shellcode for example or other loading of a binary to a Python byte array which may serve as a payload