### PR TITLE
Add installation instructions for Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,12 @@ Which will compile the release version, run tests and install release binary to 
 
 If `<USERDIR>/.cargo/bin` is part of the `PATH` environment variable, `hx` should be able to be executed anywhere in the shell.
 
+### arch linux install
+
+```
+pacman -S hex
+```
+
 ### debian install
 
 ```sh


### PR DESCRIPTION
Hey!
`hex` can be installed from Arch Linux [community] repository: https://archlinux.org/packages/community/x86_64/hex/
This PR adds installation instruction to README.md