### PR TITLE
Add 'prefix' option for optional prefixing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,7 +163,13 @@ pub fn hex_binary(b: u8) -> String {
 }
 
 /// print byte to std out
-pub fn print_byte(w: &mut impl Write, b: u8, format: Format, colorize: bool) -> io::Result<()> {
+pub fn print_byte(
+    w: &mut impl Write,
+    b: u8,
+    format: Format,
+    colorize: bool,
+    _prefix: bool,
+) -> io::Result<()> {
     if colorize {
         // note, for color testing: for (( i = 0; i < 256; i++ )); do echo "$(tput setaf $i)This is ($i) $(tput sgr0)"; done
         let color = byte_to_color(b);
@@ -271,6 +277,7 @@ pub fn run(matches: ArgMatches) -> Result<(), Box<dyn Error>> {
         };
         let mut format_out = Format::LowerHex;
         let mut colorize = true;
+        let mut enable_prefix = false;
 
         if let Some(columns) = matches.value_of(ARG_COL) {
             column_width = columns.parse::<u64>().unwrap(); //turbofish
@@ -278,6 +285,10 @@ pub fn run(matches: ArgMatches) -> Result<(), Box<dyn Error>> {
 
         if let Some(length) = matches.value_of(ARG_LEN) {
             truncate_len = length.parse::<u64>()?;
+        }
+
+        if let Some(prefix) = matches.value_of(ARG_PFX) {
+            enable_prefix = prefix.parse::<u8>().unwrap() != 0;
         }
 
         if let Some(format) = matches.value_of(ARG_FMT) {
@@ -340,7 +351,7 @@ pub fn run(matches: ArgMatches) -> Result<(), Box<dyn Error>> {
                 for hex in line.hex_body.iter() {
                     offset_counter += 1;
                     byte_column += 1;
-                    print_byte(&mut locked, *hex, format_out, colorize)?;
+                    print_byte(&mut locked, *hex, format_out, colorize, enable_prefix)?;
                     append_ascii(&mut ascii_line.ascii, *hex, colorize);
                 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -396,11 +396,19 @@ pub fn run(matches: ArgMatches) -> Result<(), Box<dyn Error>> {
                 }
 
                 if byte_column < column_width {
+                    let mut step = match format_out {
+                        Format::Octal => 7,
+                        Format::LowerHex => 5,
+                        Format::UpperHex => 5,
+                        Format::Binary => 11,
+                        _ => 5,
+                    };
+                    step -= if enable_prefix { 0 } else { 2 };
                     write!(
                         locked,
                         "{:<1$}",
                         "",
-                        5 * (column_width - byte_column) as usize
+                        step * (column_width - byte_column) as usize
                     )?;
                 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,9 +147,19 @@ pub fn hex_octal(b: u8) -> String {
     format!("{:#06o}", b)
 }
 
+/// hex octal without prefix, takes u8
+pub fn hex_octal_without_prefix(b: u8) -> String {
+    format!("{:04o}", b)
+}
+
 /// hex lower hex, takes u8
 pub fn hex_lower_hex(b: u8) -> String {
     format!("{:#04x}", b)
+}
+
+/// hex lower hex without prefix, takes u8
+pub fn hex_lower_hex_without_prefix(b: u8) -> String {
+    format!("{:02x}", b)
 }
 
 /// hex upper hex, takes u8
@@ -157,9 +167,19 @@ pub fn hex_upper_hex(b: u8) -> String {
     format!("{:#04X}", b)
 }
 
+/// hex upper hex without prefix, takes u8
+pub fn hex_upper_hex_without_prefix(b: u8) -> String {
+    format!("{:02X}", b)
+}
+
 /// hex binary, takes u8
 pub fn hex_binary(b: u8) -> String {
     format!("{:#010b}", b)
+}
+
+/// hex binary without prefix, takes u8
+pub fn hex_binary_without_prefix(b: u8) -> String {
+    format!("{:08b}", b)
 }
 
 /// print byte to std out
@@ -168,7 +188,7 @@ pub fn print_byte(
     b: u8,
     format: Format,
     colorize: bool,
-    _prefix: bool,
+    prefix: bool,
 ) -> io::Result<()> {
     if colorize {
         // note, for color testing: for (( i = 0; i < 256; i++ )); do echo "$(tput setaf $i)This is ($i) $(tput sgr0)"; done
@@ -179,37 +199,57 @@ pub fn print_byte(
                 "{} ",
                 ansi_term::Style::new()
                     .fg(ansi_term::Color::Fixed(color))
-                    .paint(hex_octal(b))
+                    .paint(if prefix {
+                        hex_octal(b)
+                    } else {
+                        hex_octal_without_prefix(b)
+                    })
             ),
             Format::LowerHex => write!(
                 w,
                 "{} ",
                 ansi_term::Style::new()
                     .fg(ansi_term::Color::Fixed(color))
-                    .paint(hex_lower_hex(b))
+                    .paint(if prefix {
+                        hex_lower_hex(b)
+                    } else {
+                        hex_lower_hex_without_prefix(b)
+                    })
             ),
             Format::UpperHex => write!(
                 w,
                 "{} ",
                 ansi_term::Style::new()
                     .fg(ansi_term::Color::Fixed(color))
-                    .paint(hex_upper_hex(b))
+                    .paint(if prefix {
+                        hex_upper_hex(b)
+                    } else {
+                        hex_upper_hex_without_prefix(b)
+                    })
             ),
             Format::Binary => write!(
                 w,
                 "{} ",
                 ansi_term::Style::new()
                     .fg(ansi_term::Color::Fixed(color))
-                    .paint(hex_binary(b))
+                    .paint(if prefix {
+                        hex_binary(b)
+                    } else {
+                        hex_binary_without_prefix(b)
+                    })
             ),
             _ => write!(w, "unk_fmt "),
         }
     } else {
         match format {
-            Format::Octal => write!(w, "{} ", hex_octal(b)),
-            Format::LowerHex => write!(w, "{} ", hex_lower_hex(b)),
-            Format::UpperHex => write!(w, "{} ", hex_upper_hex(b)),
-            Format::Binary => write!(w, "{} ", hex_binary(b)),
+            Format::Octal if prefix => write!(w, "{} ", hex_octal(b)),
+            Format::Octal => write!(w, "{} ", hex_octal_without_prefix(b)),
+            Format::LowerHex if prefix => write!(w, "{} ", hex_lower_hex(b)),
+            Format::LowerHex => write!(w, "{} ", hex_lower_hex_without_prefix(b)),
+            Format::UpperHex if prefix => write!(w, "{} ", hex_upper_hex(b)),
+            Format::UpperHex => write!(w, "{} ", hex_upper_hex_without_prefix(b)),
+            Format::Binary if prefix => write!(w, "{} ", hex_binary(b)),
+            Format::Binary => write!(w, "{} ", hex_binary_without_prefix(b)),
             _ => write!(w, "unk_fmt "),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,9 +41,11 @@ pub const ARG_ARR: &str = "array";
 pub const ARG_FNC: &str = "func";
 /// arg places
 pub const ARG_PLC: &str = "places";
+/// arg prefix
+pub const ARG_PFX: &str = "prefix";
 
-const ARGS: [&str; 8] = [
-    ARG_COL, ARG_LEN, ARG_FMT, ARG_INP, ARG_CLR, ARG_ARR, ARG_FNC, ARG_PLC,
+const ARGS: [&str; 9] = [
+    ARG_COL, ARG_LEN, ARG_FMT, ARG_INP, ARG_CLR, ARG_ARR, ARG_FNC, ARG_PLC, ARG_PFX,
 ];
 
 const DBG: u8 = 0x0;

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,7 +86,8 @@ fn main() {
                 .long(ARG_PFX)
                 .help("Set prefix presence. 0 to disable, 1 to enable")
                 .possible_values(&["0", "1"])
-                .takes_value(true),
+                .default_value("1")
+                .takes_value(true)
         );
 
     let matches = app.get_matches();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 extern crate clap;
 mod lib;
 use clap::{App, Arg};
-use lib::{ARG_ARR, ARG_CLR, ARG_COL, ARG_FMT, ARG_FNC, ARG_INP, ARG_LEN, ARG_PLC};
+use lib::{ARG_ARR, ARG_CLR, ARG_COL, ARG_FMT, ARG_FNC, ARG_INP, ARG_LEN, ARG_PFX, ARG_PLC};
 use std::env;
 use std::io::Error;
 use std::io::ErrorKind;
@@ -78,6 +78,14 @@ fn main() {
                 .long(ARG_PLC)
                 .value_name("func_places")
                 .help("Set function wave output decimal places")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name(ARG_PFX)
+                .short("r")
+                .long(ARG_PFX)
+                .help("Set prefix presence. 0 to disable, 1 to enable")
+                .possible_values(&["0", "1"])
                 .takes_value(true),
         );
 


### PR DESCRIPTION
### Description
- Add `--prefix` option (`-r` for shorthand)
- Be able to set the presence of prefix (e.g. `0x`, `0b`, ...)
- Issue: #64 

![Screenshot from 2022-01-02 20-35-19](https://user-images.githubusercontent.com/9913176/147874486-788c1f3b-7ccb-447a-af76-c108fa0a7704.png)
