### PR TITLE
Generate source code for F# arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,18 @@ pacman -S hex
 curl -sLO https://github.com/sitkevij/hex/releases/download/v0.4.2/hx_0.4.2_amd64.deb && dpkg -i hx_0.4.2_amd64.deb
 ```
 
+### guix install
+
+```sh
+guix install hex
+```
+
+In an isolated environment:
+
+```sh
+guix shell --container hex
+```
+
 ### docker run
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -191,6 +191,15 @@ let a: [UInt8] = [
 ]
 ```
 
+#### fsharp array: -af
+
+```sh
+$ hx -af -c8 tests/files/tiny.txt
+let a = [|
+    0x69uy; 0x6cuy; 0x0auy
+|]
+```
+
 ### NO_COLOR support
 
 `hx` will honor the NO_COLOR environment variable. If set, no color will be output to the terminal.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -419,6 +419,7 @@ pub fn output_array(
         "k" => writeln!(locked, "val a = byteArrayOf(")?,
         "j" => writeln!(locked, "byte[] a = new byte[]{{")?,
         "s" => writeln!(locked, "let a: [UInt8] = [")?,
+        "f" => writeln!(locked, "let a = [|")?,
         _ => writeln!(locked, "unknown array format")?,
     }
     let mut i: u64 = 0x0;
@@ -427,9 +428,17 @@ pub fn output_array(
         for hex in line.hex_body.iter() {
             i += 1;
             if i == page.bytes && array_format != "g" {
-                write!(locked, "{}", hex_lower_hex(*hex))?;
+                if array_format != "f" {
+                    write!(locked, "{}", hex_lower_hex(*hex))?;
+                } else {
+                    write!(locked, "{}uy", hex_lower_hex(*hex))?;
+                }
             } else {
-                write!(locked, "{}, ", hex_lower_hex(*hex))?;
+                if array_format != "f" {
+                    write!(locked, "{}, ", hex_lower_hex(*hex))?;
+                } else {
+                    write!(locked, "{}uy; ", hex_lower_hex(*hex))?;
+                }
             }
         }
         writeln!(locked)?;
@@ -445,6 +454,7 @@ pub fn output_array(
             "p" => "]",
             "k" => ")",
             "s" => "]",
+            "f" => "|]",
             _ => "unknown array format",
         }
     )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -433,12 +433,10 @@ pub fn output_array(
                 } else {
                     write!(locked, "{}uy", hex_lower_hex(*hex))?;
                 }
+            } else if array_format != "f" {
+                write!(locked, "{}, ", hex_lower_hex(*hex))?;
             } else {
-                if array_format != "f" {
-                    write!(locked, "{}, ", hex_lower_hex(*hex))?;
-                } else {
-                    write!(locked, "{}uy; ", hex_lower_hex(*hex))?;
-                }
+                write!(locked, "{}uy; ", hex_lower_hex(*hex))?;
             }
         }
         writeln!(locked)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,8 +60,8 @@ fn main() {
                 .short("a")
                 .long(ARG_ARR)
                 .value_name("array_format")
-                .help("Set source code format output: rust (r), C (c), golang (g), python (p), kotlin (k), java (j), swift (s)")
-                .possible_values(&["r", "c", "g", "p", "k", "j", "s"])
+                .help("Set source code format output: rust (r), C (c), golang (g), python (p), kotlin (k), java (j), swift (s), fsharp (f)")
+                .possible_values(&["r", "c", "g", "p", "k", "j", "s", "f"])
                 .takes_value(true),
         )
         .arg(


### PR DESCRIPTION
I added source code output for F# arrays. They use a semicolon instead of a comma as the delimiter, and each literal needs to have the `uy` suffix, or the F# compiler will complain. That's why I had to special case the new `f` array format.