### PR TITLE
Refactoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.4"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab91ebe16eb252986481c5b62f6098f3b698a45e34b5b98200cf20dd2484a44"
+checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -27,33 +27,33 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.4"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
+checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317b9a89c1868f5ea6ff1d9539a69f45dffc21ce321ac1fd1160dfa48c8e2140"
+checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
 dependencies = [
  "windows-sys",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.1"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
+checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
 dependencies = [
  "anstyle",
  "windows-sys",
@@ -61,9 +61,9 @@ dependencies = [
 
 [[package]]
 name = "assert_cmd"
-version = "2.0.12"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88903cb14723e4d4003335bb7f8a14f27691649105346a0f0957466c096adfe6"
+checksum = "ed72493ac66d5804837f480ab3766c72bdfab91a65e565fc54fa9e42db0073a8"
 dependencies = [
  "anstyle",
  "bstr",
@@ -82,9 +82,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bstr"
-version = "1.8.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "542f33a8835a0884b006a0c3df3dadd99c0c3f296ed26c2fdc8028e01ad6230c"
+checksum = "05efc5cfd9110c8416e471df0e96702d58690178e206e61b7173706673c93706"
 dependencies = [
  "memchr",
  "regex-automata",
@@ -102,18 +102,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.8"
+version = "4.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2275f18819641850fa26c89acc84d465c1bf91ce57bc2748b28c420473352f64"
+checksum = "949626d00e063efc93b6dca932419ceb5432f99769911c0b995f7e884c778813"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.4.8"
+version = "4.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07cdf1b148b25c1e1f7a42225e30a0d99a615cd4637eae7365548dd4529b95bc"
+checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
 dependencies = [
  "anstream",
  "anstyle",
@@ -123,9 +123,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "colorchoice"
@@ -144,12 +144,6 @@ name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
-
-[[package]]
-name = "either"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "envmnt"
@@ -204,25 +198,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "libc"
-version = "0.2.47"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48450664a984b25d5b479554c29cc04e3150c97aa4c01da5604a2d4ed9151476"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "memchr"
-version = "2.6.4"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
+checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "nias"
@@ -238,13 +223,12 @@ checksum = "bdf5e47de39a83b44018b2ee76a7a2643f37738ee44da99e145bc9804b341dd4"
 
 [[package]]
 name = "predicates"
-version = "3.0.4"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dfc28575c2e3f19cb3c73b93af36460ae898d426eba6fc15b9bd2a5220758a0"
+checksum = "68b87bfd4605926cdfefc1c3b5f8fe560e3feca9d5552cf68c466d3d8236c7e8"
 dependencies = [
  "anstyle",
  "difflib",
- "itertools",
  "predicates-core",
 ]
 
@@ -266,27 +250,27 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.69"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "regex-automata"
-version = "0.4.3"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 
 [[package]]
 name = "rusty-hook"
@@ -302,18 +286,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.192"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bca2a08484b285dcb282d0f67b26cadc0df8b19f8c12502c13d966bf9482f001"
+checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.192"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6c7207fbec9faa48073f3e3074cbe553af6ea512d7c21ba46e434e70ea9fbc1"
+checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -322,15 +306,15 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
 
 [[package]]
 name = "syn"
-version = "2.0.39"
+version = "2.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
+checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -360,9 +344,9 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.5"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
+checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
 name = "utf8parse"
@@ -381,9 +365,9 @@ dependencies = [
 
 [[package]]
 name = "winapi"
-version = "0.3.6"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
 dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
@@ -403,18 +387,18 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
  "windows-targets",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.48.5"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
@@ -427,42 +411,42 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.5"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.5"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.5"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"

--- a/src/format.rs
+++ b/src/format.rs
@@ -1,0 +1,59 @@
+/// nothing ⇒ Display
+/// ? ⇒ Debug
+/// o ⇒ Octal
+/// x ⇒ LowerHex
+/// X ⇒ UpperHex
+/// p ⇒ Pointer
+/// b ⇒ Binary
+/// e ⇒ LowerExp
+/// E ⇒ UpperExp
+/// evaluate for traits implementation
+#[derive(Copy, Clone, Debug)]
+pub enum Format {
+    /// octal format
+    Octal,
+    /// lower hex format
+    LowerHex,
+    /// upper hex format
+    UpperHex,
+    /// pointer format
+    Pointer,
+    /// binary format
+    Binary,
+    /// lower exp format
+    LowerExp,
+    /// upper exp format
+    UpperExp,
+    /// unknown format
+    Unknown,
+}
+
+impl Format {
+    /// Formats a given u8 according to the base Format
+    ///
+    /// # Arguments
+    ///
+    /// * `data` - The byte to be formatted
+    /// * `prefix` - whether or not to add a prefix
+    pub fn format(&self, data: u8, prefix: bool) -> String {
+        if prefix {
+            match &self {
+                Self::Octal => format!("{:#06o}", data),
+                Self::LowerHex => format!("{:#04x}", data),
+                Self::UpperHex => format!("{:#04X}", data),
+                Self::Binary => format!("{:#010b}", data),
+                _ => panic!("format is not implemented for this Format"),
+            }
+            .to_string()
+        } else {
+            match &self {
+                Self::Octal => format!("{:04o}", data),
+                Self::LowerHex => format!("{:02x}", data),
+                Self::UpperHex => format!("{:02X}", data),
+                Self::Binary => format!("{:08b}", data),
+                _ => panic!("format is not implemented for this Format"),
+            }
+            .to_string()
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,15 +116,10 @@ pub fn print_byte(
     if colorize {
         // note, for color testing: for (( i = 0; i < 256; i++ )); do echo "$(tput setaf $i)This is ($i) $(tput sgr0)"; done
         let color = byte_to_color(b);
-        write!(
-            w,
-            "{} ",
-            ansi_term::Style::new()
-                .fg(ansi_term::Color::Fixed(color))
-                .paint(fmt_string)
-        )
+        let string = ansi_term::Style::new().fg(color).paint(fmt_string);
+        write!(w, "{string} ",)
     } else {
-        write!(w, "{} ", fmt_string)
+        write!(w, "{fmt_string} ")
     }
 }
 
@@ -147,11 +142,9 @@ pub fn append_ascii(target: &mut Vec<u8>, b: u8, colorize: bool) {
 
     if colorize {
         let string = ansi_term::Style::new()
-            .fg(ansi_term::Color::Fixed(byte_to_color(b)))
-            .paint(char.to_string());
-        target.extend(format!("{}", string).as_bytes());
+        target.extend(format!("{string}").as_bytes());
     } else {
-        target.extend(format!("{}", char).as_bytes());
+        target.extend(format!("{char}").as_bytes());
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ mod tests;
 mod format;
 use crate::format::Format;
 
+use ansi_term::Color;
 use clap::ArgMatches;
 use no_color::is_no_color;
 use std::env;
@@ -128,11 +129,13 @@ pub fn print_byte(
 }
 
 /// get the color for a specific byte
-pub fn byte_to_color(b: u8) -> u8 {
-    match b {
+pub fn byte_to_color(b: u8) -> Color {
+    let color = match b {
         0 => 0x16,
-        _ => b
-    }
+        _ => b,
+    };
+
+    ansi_term::Color::Fixed(color)
 }
 
 /// append char representation of a byte to a buffer

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -399,9 +399,9 @@ pub fn output_array(
 /// * `places` - Number of decimal places for function wave floats.
 pub fn output_function(len: u64, places: usize) {
     for y in 0..len {
-        let y_float: f64 = y as f64;
-        let len_float: f64 = len as f64;
-        let x: f64 = (((y_float / len_float) * f64::consts::PI) / 2.0).sin();
+        let y_float = y as f64;
+        let len_float = len as f64;
+        let x = (((y_float / len_float) * f64::consts::PI) / 2.0).sin();
         let formatted_number = format!("{:.*}", places, x);
         print!("{}", formatted_number);
         print!(",");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,7 @@ pub struct Line {
     /// total bytes in Line
     pub bytes: u64,
 }
+
 /// Line implementation
 impl Line {
     /// Line constructor

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,9 @@
 extern crate ansi_term;
 extern crate clap;
 
+#[cfg(test)]
+mod tests;
+
 use clap::ArgMatches;
 use no_color::is_no_color;
 use std::env;
@@ -517,134 +520,4 @@ pub fn buf_to_array(
     }
     page.body.push(line);
     Ok(page)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    /// @see (https://users.rust-lang.org/t/how-to-test-output-to-stdout/4877/6)
-    #[test]
-    fn test_offset() {
-        let b: u64 = 0x6;
-        assert_eq!(offset(b), "0x000006");
-        assert_eq!(offset(b), format!("{:#08x}", b));
-    }
-
-    /// hex octal, takes u8
-    #[test]
-    pub fn test_hex_octal() {
-        let b: u8 = 0x6;
-
-        //with prefix
-        assert_eq!(Format::Octal.format(b, true), "0o0006");
-        assert_eq!(Format::Octal.format(b, true), format!("{:#06o}", b));
-
-        //without prefix
-        assert_eq!(Format::Octal.format(b, false), "0006");
-        assert_eq!(Format::Octal.format(b, false), format!("{:04o}", b));
-    }
-
-    /// hex lower hex, takes u8
-    #[test]
-    fn test_hex_lower_hex() {
-        let b: u8 = <u8>::max_value(); // 255
-
-        //with prefix
-        assert_eq!(Format::LowerHex.format(b, true), "0xff");
-        assert_eq!(Format::LowerHex.format(b, true), format!("{:#04x}", b));
-
-        //without prefix
-        assert_eq!(Format::LowerHex.format(b, false), "ff");
-        assert_eq!(Format::LowerHex.format(b, false), format!("{:02x}", b));
-    }
-
-    /// hex upper hex, takes u8
-    #[test]
-    fn test_hex_upper_hex() {
-        let b: u8 = <u8>::max_value();
-
-        //with prefix
-        assert_eq!(Format::UpperHex.format(b, true), "0xFF");
-        assert_eq!(Format::UpperHex.format(b, true), format!("{:#04X}", b));
-
-        // without prefix
-        assert_eq!(Format::UpperHex.format(b, false), "FF");
-        assert_eq!(Format::UpperHex.format(b, false), format!("{:02X}", b));
-    }
-
-    /// hex binary, takes u8
-    #[test]
-    fn test_hex_binary() {
-        let b: u8 = <u8>::max_value();
-
-        // with prefix
-        assert_eq!(Format::Binary.format(b, true), "0b11111111");
-        assert_eq!(Format::Binary.format(b, true), format!("{:#010b}", b));
-
-        // without prefix
-        assert_eq!(Format::Binary.format(b, false), "11111111");
-        assert_eq!(Format::Binary.format(b, false), format!("{:08b}", b));
-    }
-
-    #[test]
-    fn test_line_struct() {
-        let mut ascii_line: Line = Line::new();
-        ascii_line.ascii.push(b'.');
-        assert_eq!(ascii_line.ascii[0], b'.');
-        assert_eq!(ascii_line.offset, 0x0);
-    }
-
-    use assert_cmd::Command;
-
-    /// target/debug/hx -ar tests/files/tiny.txt
-    /// assert may have unexpected results depending on terminal:
-    ///     .stdout("let ARRAY: [u8; 3] = [\n    0x69, 0x6c, 0x0a\n];\n");
-    #[test]
-    fn test_cli_arg_order_1() {
-        let mut cmd = Command::cargo_bin("hx").unwrap();
-        let assert = cmd.arg("-ar").arg("tests/files/tiny.txt").assert();
-        assert.success().code(0);
-    }
-
-    /// target/debug/hx tests/files/tiny.txt -ar
-    /// assert may have unexpected results depending on terminal:
-    ///     .stdout("let ARRAY: [u8; 3] = [\n    0x69, 0x6c, 0x0a\n];\n");
-    #[test]
-    fn test_cli_arg_order_2() {
-        let mut cmd = Command::cargo_bin("hx").unwrap();
-        let assert = cmd.arg("tests/files/tiny.txt").arg("-ar").assert();
-        assert.success().code(0);
-    }
-
-    /// target/debug/hx --len tests/files/tiny.txt
-    ///     error: invalid digit found in string
-    #[test]
-    fn test_cli_missing_param_value() {
-        let mut cmd = Command::cargo_bin("hx").unwrap();
-        let assert = cmd.arg("--len").arg("tests/files/tiny.txt").assert();
-        assert.failure().code(1);
-    }
-
-    #[test]
-    fn test_cli_input_missing_file() {
-        let mut cmd = Command::cargo_bin("hx").unwrap();
-        let assert = cmd.arg("missing-file").assert();
-        assert.failure().code(1);
-    }
-
-    #[test]
-    fn test_cli_input_directory() {
-        let mut cmd = Command::cargo_bin("hx").unwrap();
-        let assert = cmd.arg("src").assert();
-        assert.failure().code(1);
-    }
-
-    #[test]
-    fn test_cli_input_stdin() {
-        let mut cmd = Command::cargo_bin("hx").unwrap();
-        let assert = cmd.arg("-t0").write_stdin("012").assert();
-        assert.success().code(0).stdout(
-            "0x000000: 0x30 0x31 0x32                                    012\n   bytes: 3\n",
-        );
-    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -425,7 +425,7 @@ pub fn buf_to_array(
     column_width: u64,
 ) -> Result<Page, Box<dyn ::std::error::Error>> {
     let mut column_count: u64 = 0x0;
-    let max_array_size: u16 = <u16>::max_value(); // 2^16;
+    let max_array_size = u16::MAX; // 2^16;
     let mut page: Page = Page::new();
     let mut line: Line = Line::new();
     for b in buf.bytes() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,11 +129,10 @@ pub fn print_byte(
 
 /// get the color for a specific byte
 pub fn byte_to_color(b: u8) -> u8 {
-    let mut color: u8 = b;
-    if color < 1 {
-        color = 0x16;
+    match b {
+        0 => 0x16,
+        _ => b
     }
-    color
 }
 
 /// append char representation of a byte to a buffer

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,9 @@ extern crate clap;
 #[cfg(test)]
 mod tests;
 
+mod format;
+use crate::format::Format;
+
 use clap::ArgMatches;
 use no_color::is_no_color;
 use std::env;
@@ -52,66 +55,6 @@ const ARGS: [&str; 9] = [
 ];
 
 const DBG: u8 = 0x0;
-
-/// nothing ⇒ Display
-/// ? ⇒ Debug
-/// o ⇒ Octal
-/// x ⇒ LowerHex
-/// X ⇒ UpperHex
-/// p ⇒ Pointer
-/// b ⇒ Binary
-/// e ⇒ LowerExp
-/// E ⇒ UpperExp
-/// evaluate for traits implementation
-#[derive(Copy, Clone, Debug)]
-pub enum Format {
-    /// octal format
-    Octal,
-    /// lower hex format
-    LowerHex,
-    /// upper hex format
-    UpperHex,
-    /// pointer format
-    Pointer,
-    /// binary format
-    Binary,
-    /// lower exp format
-    LowerExp,
-    /// upper exp format
-    UpperExp,
-    /// unknown format
-    Unknown,
-}
-
-impl Format {
-    /// Formats a given u8 according to the base Format
-    ///
-    /// # Arguments
-    ///
-    /// * `data` - The byte to be formatted
-    /// * `prefix` - whether or not to add a prefix
-    fn format(&self, data: u8, prefix: bool) -> String {
-        if prefix {
-            match &self {
-                Self::Octal => format!("{:#06o}", data),
-                Self::LowerHex => format!("{:#04x}", data),
-                Self::UpperHex => format!("{:#04X}", data),
-                Self::Binary => format!("{:#010b}", data),
-                _ => panic!("format is not implemented for this Format"),
-            }
-            .to_string()
-        } else {
-            match &self {
-                Self::Octal => format!("{:04o}", data),
-                Self::LowerHex => format!("{:02x}", data),
-                Self::UpperHex => format!("{:02X}", data),
-                Self::Binary => format!("{:08b}", data),
-                _ => panic!("format is not implemented for this Format"),
-            }
-            .to_string()
-        }
-    }
-}
 
 /// Line structure for hex output
 #[derive(Clone, Debug, Default)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,19 +1,4 @@
-#![deny(
-    dead_code,
-    missing_docs,
-    missing_debug_implementations,
-    missing_copy_implementations,
-    trivial_casts,
-    trivial_numeric_casts,
-    unsafe_code,
-    unstable_features,
-    unused_import_braces,
-    unused_qualifications
-)]
-
 //! general hex lib
-extern crate ansi_term;
-extern crate clap;
 
 #[cfg(test)]
 mod tests;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,16 +135,19 @@ pub fn byte_to_color(b: u8) -> Color {
 
 /// append char representation of a byte to a buffer
 pub fn append_ascii(target: &mut Vec<u8>, b: u8, colorize: bool) {
-    let char = match b > 31 && b < 127 {
+    let chr = match b > 31 && b < 127 {
         true => b as char,
         false => '.',
     };
 
     if colorize {
         let string = ansi_term::Style::new()
+            .fg(byte_to_color(b))
+            .paint(chr.to_string());
+
         target.extend(format!("{string}").as_bytes());
     } else {
-        target.extend(format!("{char}").as_bytes());
+        target.extend(format!("{chr}").as_bytes());
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -423,7 +423,7 @@ pub fn buf_to_array(
     buf_len: u64,
     column_width: u64,
 ) -> Result<Page, Box<dyn ::std::error::Error>> {
-    let mut column_count: u64 = 0x0;
+    let mut column_count = 0u64;
     let max_array_size = u16::MAX; // 2^16;
     let mut page: Page = Page::new();
     let mut line: Line = Line::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,3 @@
-extern crate clap;
-
 use clap::Arg;
 use clap::Command;
 use std::env;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,0 +1,127 @@
+use super::*;
+/// @see (https://users.rust-lang.org/t/how-to-test-output-to-stdout/4877/6)
+#[test]
+fn test_offset() {
+    let b: u64 = 0x6;
+    assert_eq!(offset(b), "0x000006");
+    assert_eq!(offset(b), format!("{:#08x}", b));
+}
+
+/// hex octal, takes u8
+#[test]
+pub fn test_hex_octal() {
+    let b: u8 = 0x6;
+
+    //with prefix
+    assert_eq!(Format::Octal.format(b, true), "0o0006");
+    assert_eq!(Format::Octal.format(b, true), format!("{:#06o}", b));
+
+    //without prefix
+    assert_eq!(Format::Octal.format(b, false), "0006");
+    assert_eq!(Format::Octal.format(b, false), format!("{:04o}", b));
+}
+
+/// hex lower hex, takes u8
+#[test]
+fn test_hex_lower_hex() {
+    let b: u8 = <u8>::max_value(); // 255
+
+    //with prefix
+    assert_eq!(Format::LowerHex.format(b, true), "0xff");
+    assert_eq!(Format::LowerHex.format(b, true), format!("{:#04x}", b));
+
+    //without prefix
+    assert_eq!(Format::LowerHex.format(b, false), "ff");
+    assert_eq!(Format::LowerHex.format(b, false), format!("{:02x}", b));
+}
+
+/// hex upper hex, takes u8
+#[test]
+fn test_hex_upper_hex() {
+    let b: u8 = <u8>::max_value();
+
+    //with prefix
+    assert_eq!(Format::UpperHex.format(b, true), "0xFF");
+    assert_eq!(Format::UpperHex.format(b, true), format!("{:#04X}", b));
+
+    // without prefix
+    assert_eq!(Format::UpperHex.format(b, false), "FF");
+    assert_eq!(Format::UpperHex.format(b, false), format!("{:02X}", b));
+}
+
+/// hex binary, takes u8
+#[test]
+fn test_hex_binary() {
+    let b: u8 = <u8>::max_value();
+
+    // with prefix
+    assert_eq!(Format::Binary.format(b, true), "0b11111111");
+    assert_eq!(Format::Binary.format(b, true), format!("{:#010b}", b));
+
+    // without prefix
+    assert_eq!(Format::Binary.format(b, false), "11111111");
+    assert_eq!(Format::Binary.format(b, false), format!("{:08b}", b));
+}
+
+#[test]
+fn test_line_struct() {
+    let mut ascii_line: Line = Line::new();
+    ascii_line.ascii.push(b'.');
+    assert_eq!(ascii_line.ascii[0], b'.');
+    assert_eq!(ascii_line.offset, 0x0);
+}
+
+use assert_cmd::Command;
+
+/// target/debug/hx -ar tests/files/tiny.txt
+/// assert may have unexpected results depending on terminal:
+///     .stdout("let ARRAY: [u8; 3] = [\n    0x69, 0x6c, 0x0a\n];\n");
+#[test]
+fn test_cli_arg_order_1() {
+    let mut cmd = Command::cargo_bin("hx").unwrap();
+    let assert = cmd.arg("-ar").arg("tests/files/tiny.txt").assert();
+    assert.success().code(0);
+}
+
+/// target/debug/hx tests/files/tiny.txt -ar
+/// assert may have unexpected results depending on terminal:
+///     .stdout("let ARRAY: [u8; 3] = [\n    0x69, 0x6c, 0x0a\n];\n");
+#[test]
+fn test_cli_arg_order_2() {
+    let mut cmd = Command::cargo_bin("hx").unwrap();
+    let assert = cmd.arg("tests/files/tiny.txt").arg("-ar").assert();
+    assert.success().code(0);
+}
+
+/// target/debug/hx --len tests/files/tiny.txt
+///     error: invalid digit found in string
+#[test]
+fn test_cli_missing_param_value() {
+    let mut cmd = Command::cargo_bin("hx").unwrap();
+    let assert = cmd.arg("--len").arg("tests/files/tiny.txt").assert();
+    assert.failure().code(1);
+}
+
+#[test]
+fn test_cli_input_missing_file() {
+    let mut cmd = Command::cargo_bin("hx").unwrap();
+    let assert = cmd.arg("missing-file").assert();
+    assert.failure().code(1);
+}
+
+#[test]
+fn test_cli_input_directory() {
+    let mut cmd = Command::cargo_bin("hx").unwrap();
+    let assert = cmd.arg("src").assert();
+    assert.failure().code(1);
+}
+
+#[test]
+fn test_cli_input_stdin() {
+    let mut cmd = Command::cargo_bin("hx").unwrap();
+    let assert = cmd.arg("-t0").write_stdin("012").assert();
+    assert
+        .success()
+        .code(0)
+        .stdout("0x000000: 0x30 0x31 0x32                                    012\n   bytes: 3\n");
+}


### PR DESCRIPTION
Extracted tests and `Format` into separate files. 
Formatted and refactored the code. 
Removed `extern crate ....` parts as they are not required in the newer versions of Rust.

`byte_to_color` also happened to be a part of refactoring as its return type was changed to `ansi_term::style::Color` because anywhere the function was called, the output was wrapped into this enum. Now it's done explicitly within the function itself.