### PR TITLE
chore: bump libc to 0.2.184

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,9 +222,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.47"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48450664a984b25d5b479554c29cc04e3150c97aa4c01da5604a2d4ed9151476"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "memchr"


### PR DESCRIPTION
Fixes compilation on loongarch64 and riscv64

To reproduce change to `Cargo.lock` locally you can run `cargo update libc` and commit that instead.

Ref https://github.com/sitkevij/hex/pull/86 https://github.com/sitkevij/hex/pull/63